### PR TITLE
chore(yazi): disable yazi plugins

### DIFF
--- a/config/yazi/.config/package.toml
+++ b/config/yazi/.config/package.toml
@@ -1,11 +1,29 @@
-[plugin]
-deps = [
-  { use = "yazi-rs/plugins:git", rev = "ec97f88" },
-  { use = "yazi-rs/plugins:full-border", rev = "ec97f88" },
-  { use = "yazi-rs/plugins:max-preview", rev = "ec97f88" },
-  { use = "yazi-rs/plugins:smart-filter", rev = "ec97f88" },
-  { use = "yazi-rs/plugins:diff", rev = "ec97f88" },
-]
+[[plugin.deps]]
+use = "yazi-rs/plugins:git"
+rev = "ec97f88"
+hash = ""
 
-[flavor]
-deps = [{ use = "yazi-rs/flavors:catppuccin-macchiato", rev = "8458d25" }]
+[[plugin.deps]]
+use = "yazi-rs/plugins:full-border"
+rev = "ec97f88"
+hash = ""
+
+[[plugin.deps]]
+use = "yazi-rs/plugins:max-preview"
+rev = "ec97f88"
+hash = ""
+
+[[plugin.deps]]
+use = "yazi-rs/plugins:smart-filter"
+rev = "ec97f88"
+hash = ""
+
+[[plugin.deps]]
+use = "yazi-rs/plugins:diff"
+rev = "ec97f88"
+hash = ""
+
+[[flavor.deps]]
+use = "yazi-rs/flavors:catppuccin-macchiato"
+rev = "8458d25"
+hash = ""

--- a/config/yazi/.config/package.toml
+++ b/config/yazi/.config/package.toml
@@ -1,29 +1,29 @@
 [[plugin.deps]]
 use = "yazi-rs/plugins:git"
-rev = "ec97f88"
-hash = ""
+rev = "3d0c7c6"
+hash = "771f18427fb75fb19990ce602bb322f4"
 
 [[plugin.deps]]
 use = "yazi-rs/plugins:full-border"
-rev = "ec97f88"
-hash = ""
+rev = "3d0c7c6"
+hash = "9dce00232a0e0e2502565c7aa2b0ed4e"
 
 [[plugin.deps]]
 use = "yazi-rs/plugins:max-preview"
-rev = "ec97f88"
-hash = ""
+rev = "3d0c7c6"
+hash = "a8025f2bb311e869069364fba01abffc"
 
 [[plugin.deps]]
 use = "yazi-rs/plugins:smart-filter"
-rev = "ec97f88"
-hash = ""
+rev = "3d0c7c6"
+hash = "f0c4b41b5d19a3144958383333eff6e7"
 
 [[plugin.deps]]
 use = "yazi-rs/plugins:diff"
-rev = "ec97f88"
-hash = ""
+rev = "3d0c7c6"
+hash = "7a08e303167d5b655c06da6d570f0333"
 
 [[flavor.deps]]
 use = "yazi-rs/flavors:catppuccin-macchiato"
-rev = "8458d25"
-hash = ""
+rev = "c023460"
+hash = "3ec21bcfd2735cfcbab61faaf43e59e4"

--- a/scripts/ansible/roles/config/tasks/main.yml
+++ b/scripts/ansible/roles/config/tasks/main.yml
@@ -72,8 +72,8 @@
 - name: Set iTerm2
   ansible.builtin.import_tasks: iterm2.yml
 
-- name: Set yazi
-  ansible.builtin.import_tasks: yazi.yml
+# - name: Set yazi
+#   ansible.builtin.import_tasks: yazi.yml
 
 - name: Set vscode
   ansible.builtin.include_tasks: vscode.yml


### PR DESCRIPTION
Disable yazi plugins
Because `ya pack` added a mysterious hash to package.toml

https://github.com/sxyazi/yazi/blob/main/yazi-cli/src/package/hash.rs