### PR TITLE
feat(setup): enhance setup script for dotfiles installation

### DIFF
--- a/data/brew/packages.yaml
+++ b/data/brew/packages.yaml
@@ -1,0 +1,662 @@
+# yaml-language-server: $schema=~/github.com/shiron-dev/dotfiles/scripts/brew-management/packages.schema.json
+
+groups:
+    uncategorized:
+        description: Uncategorized packages
+        priority: 10
+        packages:
+            - name: atlassian/acli
+              type: tap
+            - name: buildpacks/tap
+              type: tap
+            - name: hashicorp/tap
+              type: tap
+            - name: homebrew/core
+              type: tap
+            - name: shiron-dev/tap
+              type: tap
+            - name: voicevox/voicevox
+              type: tap
+            - name: abseil
+              type: brew
+            - name: act
+              type: brew
+            - name: actionlint
+              type: brew
+            - name: ansible
+              type: brew
+            - name: ansible-lint
+              type: brew
+            - name: aom
+              type: brew
+            - name: apktool
+              type: brew
+            - name: arduino-cli
+              type: brew
+            - name: aribb24
+              type: brew
+            - name: arp-scan
+              type: brew
+            - name: atlas
+              type: brew
+            - name: awscli
+              type: brew
+            - name: azure-cli
+              type: brew
+            - name: bat
+              type: brew
+            - name: boost
+              type: brew
+            - name: brotli
+              type: brew
+            - name: buf
+              type: brew
+            - name: ca-certificates
+              type: brew
+            - name: cairo
+              type: brew
+            - name: certifi
+              type: brew
+            - name: cffi
+              type: brew
+            - name: cjson
+              type: brew
+            - name: cloud-sql-proxy
+              type: brew
+            - name: cloudflared
+              type: brew
+            - name: consul-template
+              type: brew
+            - name: coreutils
+              type: brew
+            - name: cryptography
+              type: brew
+            - name: curl
+              type: brew
+            - name: dav1d
+              type: brew
+            - name: delve
+              type: brew
+            - name: docker-buildx
+              type: brew
+            - name: exiftool
+              type: brew
+            - name: fd
+              type: brew
+            - name: ffmpeg
+              type: brew
+            - name: flac
+              type: brew
+            - name: fontconfig
+              type: brew
+            - name: freetype
+              type: brew
+            - name: frei0r
+              type: brew
+            - name: fribidi
+              type: brew
+            - name: fzf
+              type: brew
+            - name: gawk
+              type: brew
+            - name: gcc
+              type: brew
+            - name: gd
+              type: brew
+            - name: gdk-pixbuf
+              type: brew
+            - name: gettext
+              type: brew
+            - name: gh
+              type: brew
+            - name: ghq
+              type: brew
+            - name: giflib
+              type: brew
+            - name: git
+              type: brew
+            - name: git-lfs
+              type: brew
+            - name: glib
+              type: brew
+            - name: gmp
+              type: brew
+            - name: gnu-sed
+              type: brew
+            - name: gnupg
+              type: brew
+            - name: gnutls
+              type: brew
+            - name: go
+              type: brew
+            - name: go-task
+              type: brew
+            - name: gofumpt
+              type: brew
+            - name: golangci-lint
+              type: brew
+            - name: goreleaser
+              type: brew
+            - name: gpgme
+              type: brew
+            - name: graphite2
+              type: brew
+            - name: graphviz
+              type: brew
+            - name: grep
+              type: brew
+            - name: grpcurl
+              type: brew
+            - name: gts
+              type: brew
+            - name: hadolint
+              type: brew
+            - name: harfbuzz
+              type: brew
+            - name: highway
+              type: brew
+            - name: htop
+              type: brew
+            - name: icu4c@77
+              type: brew
+            - name: imath
+              type: brew
+            - name: infracost
+              type: brew
+            - name: iproute2mac
+              type: brew
+            - name: isl
+              type: brew
+            - name: jasper
+              type: brew
+            - name: jpeg-turbo
+              type: brew
+            - name: jpeg-xl
+              type: brew
+            - name: jq
+              type: brew
+            - name: json-c
+              type: brew
+            - name: just
+              type: brew
+            - name: krb5
+              type: brew
+            - name: ktlint
+              type: brew
+            - name: lame
+              type: brew
+            - name: lazydocker
+              type: brew
+            - name: lazygit
+              type: brew
+            - name: leptonica
+              type: brew
+            - name: libarchive
+              type: brew
+            - name: libass
+              type: brew
+            - name: libassuan
+              type: brew
+            - name: libavif
+              type: brew
+            - name: libb2
+              type: brew
+            - name: libbluray
+              type: brew
+            - name: libcbor
+              type: brew
+            - name: libdeflate
+              type: brew
+            - name: libevent
+              type: brew
+            - name: libfido2
+              type: brew
+            - name: libgcrypt
+              type: brew
+            - name: libgit2
+              type: brew
+            - name: libgpg-error
+              type: brew
+            - name: libidn2
+              type: brew
+            - name: libksba
+              type: brew
+            - name: liblinear
+              type: brew
+            - name: libmicrohttpd
+              type: brew
+            - name: libmpc
+              type: brew
+            - name: libnghttp2
+              type: brew
+            - name: libogg
+              type: brew
+            - name: libomp
+              type: brew
+            - name: libpcap
+              type: brew
+            - name: libpng
+              type: brew
+            - name: libpq
+              type: brew
+            - name: librist
+              type: brew
+            - name: librsvg
+              type: brew
+            - name: libsamplerate
+              type: brew
+            - name: libsndfile
+              type: brew
+            - name: libsodium
+              type: brew
+            - name: libsoxr
+              type: brew
+            - name: libssh
+              type: brew
+            - name: libssh2
+              type: brew
+            - name: libtasn1
+              type: brew
+            - name: libtiff
+              type: brew
+            - name: libtool
+              type: brew
+            - name: libunibreak
+              type: brew
+            - name: libunistring
+              type: brew
+            - name: libusb
+              type: brew
+            - name: libuv
+              type: brew
+            - name: libvidstab
+              type: brew
+            - name: libvmaf
+              type: brew
+            - name: libvorbis
+              type: brew
+            - name: libvpx
+              type: brew
+            - name: libwebsockets
+              type: brew
+            - name: libx11
+              type: brew
+            - name: libxau
+              type: brew
+            - name: libxcb
+              type: brew
+            - name: libxdmcp
+              type: brew
+            - name: libxext
+              type: brew
+            - name: libxrender
+              type: brew
+            - name: libyaml
+              type: brew
+            - name: little-cms2
+              type: brew
+            - name: llvm
+              type: brew
+            - name: lua
+              type: brew
+            - name: lz4
+              type: brew
+            - name: lzo
+              type: brew
+            - name: m4
+              type: brew
+            - name: mas
+              type: brew
+            - name: mbedtls
+              type: brew
+            - name: mise
+              type: brew
+            - name: mpdecimal
+              type: brew
+            - name: mpfr
+              type: brew
+            - name: mpg123
+              type: brew
+            - name: mysql-client
+              type: brew
+            - name: mysql-client@8.0
+              type: brew
+            - name: nano
+              type: brew
+            - name: navi
+              type: brew
+            - name: ncurses
+              type: brew
+            - name: netcat
+              type: brew
+            - name: netpbm
+              type: brew
+            - name: nettle
+              type: brew
+            - name: nmap
+              type: brew
+            - name: npth
+              type: brew
+            - name: nspr
+              type: brew
+            - name: nss
+              type: brew
+            - name: oniguruma
+              type: brew
+            - name: opencore-amr
+              type: brew
+            - name: openexr
+              type: brew
+            - name: openjdk
+              type: brew
+            - name: openjpeg
+              type: brew
+            - name: openssl@3
+              type: brew
+            - name: opus
+              type: brew
+            - name: p11-kit
+              type: brew
+            - name: pack
+              type: brew
+            - name: pango
+              type: brew
+            - name: parallel
+              type: brew
+            - name: pcre2
+              type: brew
+            - name: pinentry
+              type: brew
+            - name: pinentry-mac
+              type: brew
+            - name: pipx
+              type: brew
+            - name: pixman
+              type: brew
+            - name: pkgconf
+              type: brew
+            - name: poppler
+              type: brew
+            - name: portaudio
+              type: brew
+            - name: protobuf
+              type: brew
+            - name: pycparser
+              type: brew
+            - name: python-certifi
+              type: brew
+            - name: python@3.12
+              type: brew
+            - name: python@3.13
+              type: brew
+            - name: qpdf
+              type: brew
+            - name: rav1e
+              type: brew
+            - name: readline
+              type: brew
+            - name: rename
+              type: brew
+            - name: rtmpdump
+              type: brew
+            - name: rubberband
+              type: brew
+            - name: rust
+              type: brew
+            - name: sdl2
+              type: brew
+            - name: sheldon
+              type: brew
+            - name: shellcheck
+              type: brew
+            - name: snappy
+              type: brew
+            - name: speedtest-cli
+              type: brew
+            - name: speex
+              type: brew
+            - name: sqlfluff
+              type: brew
+            - name: sqlite
+              type: brew
+            - name: srt
+              type: brew
+            - name: svt-av1
+              type: brew
+            - name: ta-lib
+              type: brew
+            - name: terraform
+              type: brew
+            - name: terraform-ls
+              type: brew
+            - name: tesseract
+              type: brew
+            - name: tflint
+              type: brew
+            - name: theora
+              type: brew
+            - name: tree
+              type: brew
+            - name: ttyd
+              type: brew
+            - name: unbound
+              type: brew
+            - name: usage
+              type: brew
+            - name: volta
+              type: brew
+            - name: watch
+              type: brew
+            - name: webp
+              type: brew
+            - name: wget
+              type: brew
+            - name: x264
+              type: brew
+            - name: x265
+              type: brew
+            - name: xc
+              type: brew
+            - name: xorgproto
+              type: brew
+            - name: xvid
+              type: brew
+            - name: xz
+              type: brew
+            - name: yamlfmt
+              type: brew
+            - name: yamllint
+              type: brew
+            - name: yazi
+              type: brew
+            - name: yq
+              type: brew
+            - name: yt-dlp
+              type: brew
+            - name: z3
+              type: brew
+            - name: zeromq
+              type: brew
+            - name: zimg
+              type: brew
+            - name: zlib
+              type: brew
+            - name: zoxide
+              type: brew
+            - name: zstd
+              type: brew
+            - name: 1password
+              type: cask
+            - name: adobe-acrobat-reader
+              type: cask
+            - name: aivis-speech
+              type: cask
+            - name: arc
+              type: cask
+            - name: arduino-ide
+              type: cask
+            - name: audacity
+              type: cask
+            - name: battery
+              type: cask
+            - name: betterdisplay
+              type: cask
+            - name: brave-browser
+              type: cask
+            - name: claude
+              type: cask
+            - name: cloudflare-warp
+              type: cask
+            - name: commander-one
+              type: cask
+            - name: cursor
+              type: cask
+            - name: discord
+              type: cask
+            - name: dmm-game-player
+              type: cask
+            - name: docker
+              type: cask
+            - name: docker-desktop
+              type: cask
+            - name: figma
+              type: cask
+            - name: figma-agent
+              type: cask
+            - name: finicky
+              type: cask
+            - name: firefox@developer-edition
+              type: cask
+            - name: flutter
+              type: cask
+            - name: font-roboto-mono-nerd-font
+              type: cask
+            - name: fujitsu-scansnap-home
+              type: cask
+            - name: gimp
+              type: cask
+            - name: gitify
+              type: cask
+            - name: google-chrome
+              type: cask
+            - name: google-cloud-sdk
+              type: cask
+            - name: inkscape
+              type: cask
+            - name: iterm2
+              type: cask
+            - name: itsycal
+              type: cask
+            - name: jetbrains-toolbox
+              type: cask
+            - name: jordanbaird-ice
+              type: cask
+            - name: keycastr
+              type: cask
+            - name: kicad
+              type: cask
+            - name: ltspice
+              type: cask
+            - name: macs-fan-control
+              type: cask
+            - name: master-pdf-editor
+              type: cask
+            - name: microsoft-auto-update
+              type: cask
+            - name: microsoft-edge
+              type: cask
+            - name: microsoft-excel
+              type: cask
+            - name: microsoft-powerpoint
+              type: cask
+            - name: microsoft-word
+              type: cask
+            - name: mysqlworkbench
+              type: cask
+            - name: notion
+              type: cask
+            - name: obs
+              type: cask
+            - name: onyx
+              type: cask
+            - name: openinterminal
+              type: cask
+            - name: orbstack
+              type: cask
+            - name: pgadmin4
+              type: cask
+            - name: postman
+              type: cask
+            - name: raycast
+              type: cask
+            - name: rwts-pdfwriter
+              type: cask
+            - name: session-manager-plugin
+              type: cask
+            - name: slack
+              type: cask
+            - name: spotify
+              type: cask
+            - name: stats
+              type: cask
+            - name: steam
+              type: cask
+            - name: tailscale
+              type: cask
+            - name: tailscale-app
+              type: cask
+            - name: termius
+              type: cask
+            - name: timemachinestatus
+              type: cask
+            - name: tor-browser
+              type: cask
+            - name: unity-hub
+              type: cask
+            - name: utm
+              type: cask
+            - name: vb-cable
+              type: cask
+            - name: visual-studio-code
+              type: cask
+            - name: visual-studio-code@insiders
+              type: cask
+            - name: vlc
+              type: cask
+            - name: voicevox
+              type: cask
+            - name: wakatime
+              type: cask
+            - name: webtorrent
+              type: cask
+            - name: wireshark
+              type: cask
+            - name: wireshark-app
+              type: cask
+            - name: zoom
+              type: cask
+            - name: AmorphousDiskMark  (4.0.1)
+              type: mas
+              id: 1168254295
+            - name: Amphetamine        (5.3.2)
+              type: mas
+              id: 937984704
+            - name: Cloud Battery      (4.43)
+              type: mas
+              id: 1481005137
+            - name: DaVinci Resolve    (20.0.1)
+              type: mas
+              id: 571213070
+            - name: Goodnotes          (6.6.49)
+              type: mas
+              id: 1444383602
+            - name: LINE               (9.9.0)
+              type: mas
+              id: 539883307
+            - name: MeetingBar         (4.11.6)
+              type: mas
+              id: 1532419400
+            - name: Xcode              (16.4)
+              type: mas
+              id: 497799835
+profiles: {}

--- a/scripts/brew-management/README.md
+++ b/scripts/brew-management/README.md
@@ -94,13 +94,13 @@ Validate YAML configuration files:
 
 ```bash
 # Validate single file
-./brew-manager validate packages-grouped.yml
+./brew-manager validate packages.yaml
 
 # Validate all YAML files in directory
 ./brew-manager validate --all /path/to/data
 
 # Verbose validation
-./brew-manager validate packages-grouped.yml --verbose
+./brew-manager validate packages.yaml --verbose
 ```
 
 ## Configuration Structure

--- a/scripts/brew-management/cmd/convert.go
+++ b/scripts/brew-management/cmd/convert.go
@@ -20,8 +20,8 @@ var convertCmd = &cobra.Command{
 	Long: `Convert a Brewfile to YAML format.
 
 Examples:
-  brew-manager convert Brewfile packages-grouped.yml      # Convert to grouped YAML format
-  brew-manager convert --grouped Brewfile packages-grouped.yml  # Convert to grouped YAML format`,
+  brew-manager convert Brewfile packages.yaml      # Convert to grouped YAML format
+  brew-manager convert --grouped Brewfile packages.yaml  # Convert to grouped YAML format`,
 	Args: cobra.ExactArgs(2),
 	Run: func(cmd *cobra.Command, args []string) {
 		brewfilePath := args[0]

--- a/scripts/brew-management/cmd/install.go
+++ b/scripts/brew-management/cmd/install.go
@@ -40,7 +40,7 @@ Examples:
   brew-manager install --groups development --brews-only # Install only brew packages from development group`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get YAML file path
-		yamlFile := getDefaultYAMLPath("packages-grouped.yml")
+		yamlFile := getDefaultYAMLPath("packages.yaml")
 		if len(args) > 0 {
 			yamlFile = args[0]
 		}

--- a/scripts/brew-management/cmd/root.go
+++ b/scripts/brew-management/cmd/root.go
@@ -59,18 +59,22 @@ func init() {
 
 // getDefaultYAMLPath returns the default path for YAML configuration files
 func getDefaultYAMLPath(filename string) string {
+	// デフォルトのYAMLパス
+	defaultPath := filepath.Join(os.Getenv("HOME"), "projects/github.com/shiron-dev/dotfiles/data/brew/packages.yaml")
+	if filename == "" || filename == "packages-grouped.yml" || filename == "packages.yml" || filename == "packages.yaml" {
+		return defaultPath
+	}
+
 	// Get current working directory
 	cwd, err := os.Getwd()
 	if err != nil {
 		return filepath.Join(".", "data", "brew", filename)
 	}
-	
 	// Look for data directory relative to current location
 	dataPath := filepath.Join(cwd, "../../data/brew", filename)
 	if utils.FileExists(dataPath) {
 		return dataPath
 	}
-	
 	// Fall back to relative path
 	return filepath.Join("data", "brew", filename)
-} 
+}

--- a/scripts/brew-management/cmd/sync.go
+++ b/scripts/brew-management/cmd/sync.go
@@ -31,7 +31,7 @@ Examples:
   brew-manager sync --auto-detect --sort               # Auto-detect groups/tags and sort`,
 	Run: func(cmd *cobra.Command, args []string) {
 		// Get YAML file path
-		yamlFile := getDefaultYAMLPath("packages-grouped.yml")
+		yamlFile := getDefaultYAMLPath("packages.yaml")
 		if len(args) > 0 {
 			yamlFile = args[0]
 		}

--- a/scripts/brew-management/cmd/validate.go
+++ b/scripts/brew-management/cmd/validate.go
@@ -37,8 +37,7 @@ Examples:
 
 		if all {
 			// Validate all YAML files in data directory
-			dataDir := getDefaultYAMLPath("")
-			dataDir = filepath.Dir(dataDir) // Remove filename to get directory
+			dataDir := filepath.Dir(getDefaultYAMLPath("packages.yaml"))
 			
 			if err := validate.ValidateAllYAMLFiles(dataDir, options); err != nil {
 				utils.PrintStatus(utils.Red, fmt.Sprintf("Validation failed: %v", err))
@@ -51,7 +50,7 @@ Examples:
 				yamlFile = args[0]
 			} else {
 				// Default to grouped config file
-				yamlFile = getDefaultYAMLPath("packages-grouped.yml")
+				yamlFile = getDefaultYAMLPath("packages.yaml")
 			}
 
 			if err := validate.ValidateYAMLFile(yamlFile, options); err != nil {

--- a/scripts/brew-management/generate.go
+++ b/scripts/brew-management/generate.go
@@ -1,3 +1,3 @@
-//go:generate go run . generate schema --verbose
+//go:generate go run ../generate.go
 
 package main

--- a/scripts/brew-management/packages.schema.json
+++ b/scripts/brew-management/packages.schema.json
@@ -1,0 +1,149 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$ref": "#/$defs/PackageGrouped",
+  "$defs": {
+    "Group": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Description",
+          "description": "Human-readable description of the group"
+        },
+        "priority": {
+          "type": "integer",
+          "maximum": 99,
+          "minimum": 1,
+          "title": "Priority",
+          "description": "Installation priority (lower numbers install first)"
+        },
+        "packages": {
+          "items": {
+            "$ref": "#/$defs/Package"
+          },
+          "type": "array",
+          "title": "Packages",
+          "description": "Packages in this group"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description",
+        "priority",
+        "packages"
+      ]
+    },
+    "Package": {
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Package Name",
+          "description": "Package name"
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "tap",
+            "brew",
+            "cask",
+            "mas"
+          ],
+          "title": "Package Type",
+          "description": "Package type"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Tags",
+          "description": "Tags for categorization and filtering"
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Description",
+          "description": "Optional description of the package"
+        },
+        "id": {
+          "type": "integer",
+          "minimum": 1,
+          "title": "App Store ID",
+          "description": "Mac App Store ID (required for mas type)"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "name",
+        "type"
+      ]
+    },
+    "PackageGrouped": {
+      "properties": {
+        "groups": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Group"
+          },
+          "type": "object",
+          "title": "Package Groups",
+          "description": "Package groups definition"
+        },
+        "profiles": {
+          "additionalProperties": {
+            "$ref": "#/$defs/Profile"
+          },
+          "type": "object",
+          "title": "Installation Profiles",
+          "description": "Installation profiles - predefined combinations"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "groups"
+      ]
+    },
+    "Profile": {
+      "properties": {
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "title": "Description",
+          "description": "Human-readable description of the profile"
+        },
+        "groups": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Groups",
+          "description": "Groups to include in this profile"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Tags",
+          "description": "Tags to include in this profile"
+        },
+        "exclude_tags": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array",
+          "title": "Exclude Tags",
+          "description": "Tags to exclude from this profile"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "description"
+      ]
+    }
+  }
+}

--- a/scripts/brew-management/pkg/utils/utils.go
+++ b/scripts/brew-management/pkg/utils/utils.go
@@ -66,6 +66,10 @@ func CheckPrerequisites() error {
 
 // GetDefaultYAMLPath returns the default path for YAML configuration files
 func GetDefaultYAMLPath(filename string) string {
+	defaultPath := filepath.Join(os.Getenv("HOME"), "projects/github.com/shiron-dev/dotfiles/data/brew/packages.yaml")
+	if filename == "" || filename == "packages-grouped.yml" || filename == "packages.yml" || filename == "packages.yaml" {
+		return defaultPath
+	}
 	dir, _ := os.Getwd()
 	return filepath.Join(dir, "../../data/brew", filename)
 }
@@ -116,24 +120,24 @@ func HasIntersection(slice1, slice2 []string) bool {
 // AutoDetectGroup attempts to determine the appropriate group for a package
 func AutoDetectGroup(packageName, packageType string) string {
 	name := strings.ToLower(packageName)
-	
+
 	switch {
-	case strings.Contains(name, "git") || strings.Contains(name, "node") || 
-		 strings.Contains(name, "python") || strings.Contains(name, "go") || 
-		 strings.Contains(name, "rust") || strings.Contains(name, "java") || 
-		 strings.Contains(name, "docker") || strings.Contains(name, "terraform") || 
-		 strings.Contains(name, "ansible"):
+	case strings.Contains(name, "git") || strings.Contains(name, "node") ||
+		strings.Contains(name, "python") || strings.Contains(name, "go") ||
+		strings.Contains(name, "rust") || strings.Contains(name, "java") ||
+		strings.Contains(name, "docker") || strings.Contains(name, "terraform") ||
+		strings.Contains(name, "ansible"):
 		return "development"
-	case name == "htop" || name == "tree" || name == "watch" || 
-		 name == "stats" || name == "battery" || name == "raycast" || 
-		 strings.Contains(name, "1password"):
+	case name == "htop" || name == "tree" || name == "watch" ||
+		name == "stats" || name == "battery" || name == "raycast" ||
+		strings.Contains(name, "1password"):
 		return "system"
-	case strings.Contains(name, "figma") || name == "obs" || name == "vlc" || 
-		 name == "audacity" || name == "gimp" || name == "inkscape":
+	case strings.Contains(name, "figma") || name == "obs" || name == "vlc" ||
+		name == "audacity" || name == "gimp" || name == "inkscape":
 		return "creative"
-	case name == "notion" || name == "slack" || name == "zoom" || 
-		 strings.Contains(name, "chrome") || strings.Contains(name, "firefox") || 
-		 name == "arc" || name == "brave":
+	case name == "notion" || name == "slack" || name == "zoom" ||
+		strings.Contains(name, "chrome") || strings.Contains(name, "firefox") ||
+		name == "arc" || name == "brave":
 		return "productivity"
 	case name == "mas" || name == "brew" || name == "yq" || name == "jq":
 		return "core"
@@ -213,7 +217,7 @@ func EnsureDir(filePath string) error {
 	if dir == "." || dir == "/" {
 		return nil
 	}
-	
+
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err := os.MkdirAll(dir, 0755); err != nil {
 			return fmt.Errorf("failed to create directory %s: %w", dir, err)
@@ -230,7 +234,7 @@ func CreateBackup(filePath string) error {
 	}
 
 	backupPath := filePath + ".backup"
-	
+
 	input, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file for backup: %w", err)
@@ -243,4 +247,4 @@ func CreateBackup(filePath string) error {
 
 	PrintStatus(Green, fmt.Sprintf("Backup created: %s", backupPath))
 	return nil
-} 
+}

--- a/scripts/brew-management/pkg/yaml/yaml.go
+++ b/scripts/brew-management/pkg/yaml/yaml.go
@@ -109,7 +109,7 @@ func SaveGroupedConfig(config *types.PackageGrouped, filePath string) error {
 	}
 
 	// Add yaml-language-server comment
-	content := "# yaml-language-server: $schema=~/github.com/shiron-dev/dotfiles/scripts/brew-management/packages.schema.json\n\n"
+	content := "# yaml-language-server: $schema=~/projects/github.com/shiron-dev/dotfiles/scripts/brew-management/packages.schema.json\n\n"
 	content += string(data)
 
 	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {

--- a/scripts/setup.bash
+++ b/scripts/setup.bash
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+set -e
+
+REPO_URL="https://github.com/shiron-dev/dotfiles.git"
+REPO_PATH="$HOME/projects/github.com/shiron-dev/dotfiles"
+
 cat <<EOM
 
 # shiron-dev dotfiles
@@ -11,20 +16,50 @@ https://github.com/shiron-dev/dotfiles
 
 EOM
 
-if [ -d ~/projects/github.com/shiron-dev/dotfiles ]; then
-  cat <<EOM
-
-dotfiles repository already exists.
-Run setup from '~/projects/github.com/shiron-dev/dotfiles'.
-
-EOM
-  cd ~/projects/github.com/shiron-dev/dotfiles/scripts/ && go run ~/projects/github.com/shiron-dev/dotfiles/scripts/main.go
+# Check Homebrew
+if ! command -v brew >/dev/null 2>&1; then
+  echo "[INFO] Homebrew not found. Installing..."
+  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 else
-  cat <<EOM
+  echo "[INFO] Homebrew found."
+fi
 
-dotfiles repository does not exist.
+# Check git
+if ! command -v git >/dev/null 2>&1; then
+  echo "[INFO] git not found. Installing via Homebrew..."
+  brew install git
+else
+  echo "[INFO] git found."
+fi
+
+# Clone dotfiles if not exists
+if [ ! -d "$REPO_PATH" ]; then
+  echo "[INFO] Cloning dotfiles repository to $REPO_PATH ..."
+  git clone "$REPO_URL" "$REPO_PATH"
+else
+  echo "[INFO] dotfiles repository already exists at $REPO_PATH."
+fi
+
+# Check Go
+if ! command -v go >/dev/null 2>&1; then
+  echo "[INFO] Go not found. Installing via Homebrew..."
+  brew install go
+else
+  echo "[INFO] Go found."
+fi
+
+# Install brew-management
+echo "[INFO] Installing brew-management..."
+cd "$REPO_PATH/scripts/brew-management" && go install
+
+cat <<EOM
+
+✅ 初期セットアップが完了しました。
+
+次のコマンドを順に実行してください：
+
+brew-management install
+cd $REPO_PATH/scripts/ansible
+ansible-playbook -i hosts.yml site.yml
 
 EOM
-  # TODO: Run from github release
-  exit 1
-fi

--- a/scripts/test.bash
+++ b/scripts/test.bash
@@ -1,7 +1,0 @@
-#!/usr/bin/env bash
-
-script_dir=$(dirname "$(realpath "${BASH_SOURCE[0]}")")
-
-cd "$script_dir/.." && docker build -t shiron-dev/dotfiles:latest -f "$script_dir/Dockerfile" .
-
-docker run -it shiron-dev/dotfiles:latest


### PR DESCRIPTION
- Added error handling with `set -e` to ensure script exits on errors.
- Introduced checks for Homebrew, git, and Go installation, with installation prompts if not found.
- Implemented cloning of the dotfiles repository if it does not already exist.
- Added instructions for post-setup commands in Japanese for user guidance.
- Removed obsolete test script as part of cleanup.