### PR TITLE
chore(vscode): add new keybindings for inline diffs and chat editing

### DIFF
--- a/config/vscode/Application Support/keybindings.json
+++ b/config/vscode/Application Support/keybindings.json
@@ -348,5 +348,25 @@
     "key": "cmd+enter",
     "command": "workbench.action.toggleMaximizedPanel",
     "when": "panelAlignment == 'center' || panelPosition != 'bottom' && panelPosition != 'top'"
+  },
+  {
+    "key": "shift+cmd+y",
+    "command": "editor.action.inlineDiffs.acceptAll",
+    "when": "editorTextFocus && @inlineDiffs.acceptAllEdits.isActiveEditorWithDiffs"
+  },
+  {
+    "key": "cmd+enter",
+    "command": "-editor.action.inlineDiffs.acceptAll",
+    "when": "editorTextFocus && @inlineDiffs.acceptAllEdits.isActiveEditorWithDiffs"
+  },
+  {
+    "key": "shift+cmd+y",
+    "command": "chatEditing.acceptAllFiles",
+    "when": "hasUndecidedChatEditingResource && inChatInput && !chatSessionRequestInProgress"
+  },
+  {
+    "key": "cmd+enter",
+    "command": "-chatEditing.acceptAllFiles",
+    "when": "hasUndecidedChatEditingResource && inChatInput && !chatSessionRequestInProgress"
   }
 ]


### PR DESCRIPTION
- Introduced keybindings for accepting all inline diffs and chat editing files.
- Removed conflicting keybindings to ensure smooth functionality in the editor.
- Enhanced user experience by streamlining commands related to editing and diff management.