### PR TITLE
ci(dotfiles): fix scope ci

### DIFF
--- a/scope-rules.json
+++ b/scope-rules.json
@@ -1,15 +1,15 @@
 {
   "rules": [
     {
-      "pattern": "^config/(.+)/.*",
+      "pattern": "^config/([^/]+)/.*",
       "scope": "$1"
     },
     {
-      "pattern": "^scripts/(.+)/.*",
+      "pattern": "^scripts/([^/]+)/.*",
       "scope": "$1"
     },
     {
-      "pattern": "^data/(.+)/.*",
+      "pattern": "^data/([^/]+)/.*",
       "scope": "$1"
     },
     {

--- a/scripts/check_pr_scope.sh
+++ b/scripts/check_pr_scope.sh
@@ -87,7 +87,7 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "pr_scopes=${pr_scopes[*]}" >> "$GITHUB_OUTPUT"
 fi
 
-if [[  ${pr_scopes[*]}  =~  \*  || ${pr_scopes[*]} =~ deps ]]; then
+if [[ ${pr_scopes[*]} =~ \* || ${pr_scopes[*]} =~ deps ]]; then
   echo "Wildcard scope '*' or 'deps' in PR title allows all changes."
   exit 0
 fi
@@ -153,4 +153,4 @@ if [ ${#missing_scopes[@]} -gt 0 ]; then
   exit 1
 else
   echo "PR title scopes are valid."
-fi 
+fi

--- a/scripts/check_pr_scope.sh
+++ b/scripts/check_pr_scope.sh
@@ -87,8 +87,8 @@ if [ -n "${GITHUB_OUTPUT:-}" ]; then
   echo "pr_scopes=${pr_scopes[*]}" >> "$GITHUB_OUTPUT"
 fi
 
-if [[  ${pr_scopes[*]}  =~  \*  ]]; then
-  echo "Wildcard scope '*' in PR title allows all changes."
+if [[  ${pr_scopes[*]}  =~  \*  || ${pr_scopes[*]} =~ deps ]]; then
+  echo "Wildcard scope '*' or 'deps' in PR title allows all changes."
   exit 0
 fi
 


### PR DESCRIPTION
This pull request introduces updates to scope-matching rules and modifies the PR scope validation script to enhance functionality. The most important changes include refining regex patterns for better scope extraction and adding support for a new `deps` scope in the PR validation logic.

### Updates to scope-matching rules:

* [`scope-rules.json`](diffhunk://#diff-18632374c97d896709c0067dc1cac6089a5e9ec9dfb90e8c7d6e2f4e42873744L4-R12): Adjusted regex patterns to ensure only the first directory in paths (`config`, `scripts`, `data`) is captured as the scope by replacing `(.+)` with `([^/]+)`. This change avoids unintended matches of deeper directory structures.

### Enhancements to PR scope validation:

* [`scripts/check_pr_scope.sh`](diffhunk://#diff-a568b7ef9942b7169b47a1aca331465c6774e9daf264dde6cf85101bd15599e9L90-R91): Updated the validation logic to recognize the `deps` scope in addition to the wildcard `*`. This allows PRs with `deps` in the title to bypass scope restrictions, facilitating dependency updates.