### PR TITLE
feat(mise): add support for additional tools in configuration

### DIFF
--- a/config/mise/.config/config.toml
+++ b/config/mise/.config/config.toml
@@ -1,4 +1,8 @@
 [tools]
+go = "1.24.4"
 java = "17"
 python = "3.13.3"
 terraform = "latest"
+
+[settings]
+idiomatic_version_file_enable_tools = ["go", "node"]


### PR DESCRIPTION
This pull request updates the configuration file to specify tool versions and enable idiomatic version file settings for certain tools.

Configuration updates:

* [`config/mise/.config/config.toml`](diffhunk://#diff-12187c3837c21afea19dd805ba23678e5e7b9f4be36902c8c0eb998dd2d5c42dR2-R8): Added Go version `1.24.4` and enabled idiomatic version file settings for `go` and `node` in the `[settings]` section.