### PR TITLE
refactor(vscode): refine condition for maximizing panel to inclu…

### DIFF
--- a/config/vscode/Application Support/keybindings.json
+++ b/config/vscode/Application Support/keybindings.json
@@ -347,7 +347,7 @@
   {
     "key": "cmd+enter",
     "command": "workbench.action.toggleMaximizedPanel",
-    "when": "panelAlignment == 'center' || panelPosition != 'bottom' && panelPosition != 'top'"
+    "when": "terminalFocus && (panelAlignment == 'center' || panelPosition != 'bottom' && panelPosition != 'top')"
   },
   {
     "key": "shift+cmd+y",


### PR DESCRIPTION
This pull request updates the `keybindings.json` configuration file to refine the conditions under which the `cmd+enter` shortcut toggles the maximized panel. The change ensures that the shortcut only works when the terminal is focused.

* [`config/vscode/Application Support/keybindings.json`](diffhunk://#diff-33af83fcc09d021c3a30688e145f873dec3d492dae577b1074bdee6a313628f8L350-R350): Updated the `when` condition for the `cmd+enter` keybinding to include `terminalFocus`, restricting its functionality to scenarios where the terminal is active.…de terminal focus